### PR TITLE
Fix rag assistant name typo and docstring

### DIFF
--- a/finrobot/functional/rag.py
+++ b/finrobot/functional/rag.py
@@ -22,7 +22,7 @@ def get_rag_function(retrieve_config, description=""):
     if "customized_prompt" not in retrieve_config:
         retrieve_config["customized_prompt"] = PROMPT_RAG_FUNC
 
-    rag_assitant = RetrieveUserProxyAgent(
+    rag_assistant = RetrieveUserProxyAgent(
         name="RAG_Assistant",
         is_termination_msg=termination_msg,
         human_input_mode="NEVER",
@@ -42,23 +42,23 @@ def get_rag_function(retrieve_config, description=""):
         n_results: Annotated[int, "Number of results to retrieve, default to 3"] = 3,
     ) -> str:
 
-        rag_assitant.n_results = n_results  # Set the number of results to be retrieved.
+        rag_assistant.n_results = n_results  # Set the number of results to be retrieved.
         # Check if we need to update the context.
-        update_context_case1, update_context_case2 = rag_assitant._check_update_context(
+        update_context_case1, update_context_case2 = rag_assistant._check_update_context(
             message
         )
         if (
             update_context_case1 or update_context_case2
-        ) and rag_assitant.update_context:
-            rag_assitant.problem = (
+        ) and rag_assistant.update_context:
+            rag_assistant.problem = (
                 message
-                if not hasattr(rag_assitant, "problem")
-                else rag_assitant.problem
+                if not hasattr(rag_assistant, "problem")
+                else rag_assistant.problem
             )
-            _, ret_msg = rag_assitant._generate_retrieve_user_reply(message)
+            _, ret_msg = rag_assistant._generate_retrieve_user_reply(message)
         else:
             _context = {"problem": message, "n_results": n_results}
-            ret_msg = rag_assitant.message_generator(rag_assitant, None, _context)
+            ret_msg = rag_assistant.message_generator(rag_assistant, None, _context)
         return ret_msg if ret_msg else message
 
     if description:
@@ -68,6 +68,6 @@ def get_rag_function(retrieve_config, description=""):
         docs = retrieve_config.get("docs_path", [])
         if docs:
             docs_str = "\n".join(docs if isinstance(docs, list) else [docs])
-            retrieve_content.__doc__ += f"Availale Documents:\n{docs_str}"
+            retrieve_content.__doc__ += f"Available Documents:\n{docs_str}"
 
-    return retrieve_content, rag_assitant  # for debug use
+    return retrieve_content, rag_assistant  # for debug use


### PR DESCRIPTION
## Summary
- rename `rag_assitant` to `rag_assistant`
- correct docstring heading to "Available Documents"

## Testing
- `pylint finrobot/functional/rag.py` *(fails: Unable to import 'autogen.agentchat.contrib.retrieve_user_proxy_agent')*

------
https://chatgpt.com/codex/tasks/task_e_68a326279cc0832cb639634d6f6ced08