### PR TITLE
refactor: replace wildcard utils import

### DIFF
--- a/finrobot/agents/workflow.py
+++ b/finrobot/agents/workflow.py
@@ -1,5 +1,5 @@
 from .agent_library import library
-from typing import Any, Callable, Dict, List, Optional, Annotated
+from typing import Any, Callable, Dict, List
 import autogen
 from autogen.cache import Cache
 from autogen import (
@@ -15,7 +15,12 @@ from functools import partial
 from abc import ABC, abstractmethod
 from ..toolkits import register_toolkits
 from ..functional.rag import get_rag_function
-from .utils import *
+from .utils import (
+    instruction_trigger,
+    instruction_message,
+    order_trigger,
+    order_message,
+)
 from .prompts import leader_system_message, role_system_message
 
 


### PR DESCRIPTION
## Summary
- replace wildcard import in workflow module with explicit utility imports
- drop unused typing aliases

## Testing
- `flake8 finrobot/agents/workflow.py --select=F401`
- `pytest` *(fails: ModuleNotFoundError: No module named 'backtrader')*

------
https://chatgpt.com/codex/tasks/task_e_68a32634cfd8832c8de2f19fa4e22830