### PR TITLE
Refactor Finnhub financials filtering

### DIFF
--- a/finrobot/data_source/finnhub_utils.py
+++ b/finrobot/data_source/finnhub_utils.py
@@ -150,9 +150,9 @@ class FinnHubUtils:
             value = value_list[0]
             output_dict.update({metric: value["v"]})
 
-        for k in output_dict.keys():
-            if selected_columns and k not in selected_columns:
-                output_dict.pop(k)
+        if selected_columns:
+            # Keep only metrics explicitly requested in selected_columns
+            output_dict = {k: v for k, v in output_dict.items() if k in selected_columns}
 
         return json.dumps(output_dict, indent=2)
 

--- a/tests/test_finnhub_utils.py
+++ b/tests/test_finnhub_utils.py
@@ -1,0 +1,48 @@
+import json
+import types
+import sys
+import pathlib
+import importlib.util
+
+# Provide a minimal pandas stub to satisfy module imports
+sys.modules.setdefault("pandas", types.SimpleNamespace(DataFrame=dict))
+
+root = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+
+# Pre-create parent packages to avoid importing heavy dependencies
+if "finrobot" not in sys.modules:
+    finrobot_pkg = types.ModuleType("finrobot")
+    finrobot_pkg.__path__ = [str(root / "finrobot")]
+    sys.modules["finrobot"] = finrobot_pkg
+if "finrobot.data_source" not in sys.modules:
+    ds_pkg = types.ModuleType("finrobot.data_source")
+    ds_pkg.__path__ = [str(root / "finrobot" / "data_source")]
+    sys.modules["finrobot.data_source"] = ds_pkg
+
+module_path = root / "finrobot/data_source/finnhub_utils.py"
+spec = importlib.util.spec_from_file_location("finrobot.data_source.finnhub_utils", module_path)
+f_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(f_utils)
+FinnHubUtils = f_utils.FinnHubUtils
+
+
+class DummyClient:
+    def company_basic_financials(self, symbol, all_arg):
+        return {
+            "metric": {"alpha": 1, "beta": 2},
+            "series": {
+                "quarterly": {
+                    "alpha": [{"v": 1}],
+                    "beta": [{"v": 2}],
+                }
+            },
+        }
+
+
+def test_get_basic_financials_filters_columns(monkeypatch):
+    monkeypatch.setenv("FINNHUB_API_KEY", "test")
+    monkeypatch.setattr(f_utils.finnhub, "Client", lambda api_key: DummyClient())
+    result = FinnHubUtils.get_basic_financials("DUM", selected_columns=["beta"])
+    parsed = json.loads(result)
+    assert parsed == {"beta": 2}


### PR DESCRIPTION
## Summary
- replace mutation loop with dictionary comprehension when filtering basic financials
- document filter behavior and add regression test ensuring JSON output for selected columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3257f63a8832cb598e556008efdf7